### PR TITLE
Consuming Json instead of needing to clone

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,11 +14,9 @@ fn index() -> &'static str {
 
 #[post("/image", format = "json", data = "<img>")]
 fn upload(img: Json<ImgurImg>) -> String {
-  let comment = match img.comment {
-    Some(inner) => inner.clone(),
-    None => String::from(""),
-  };
-  format!("The url is: '{}', the comment is: '{}'", img.url, comment)
+  let img_inner = img.into_inner();
+  let comment = img_inner.comment.unwrap_or("".into());
+  format!("The url is: '{}', the comment is: '{}'", img_inner.url, comment)
 }
 
 fn main() {


### PR DESCRIPTION
If you convert the `Json<ImgurImg>` into a `ImgurImg`, you can move a field out of it without needing to clone the field.